### PR TITLE
Enable use of FETCHCONTENT_SOURCE_DIR_FLAMEGPU2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,6 @@ project(wrapper CUDA CXX)
       
 # Our core dependency is FLAMEGPU2 lib, first lets find it
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/flamegpu2.cmake)
-# Now disable extra bells/whistles and add flamegpu2 as a dependency
-set(NO_EXAMPLES ON CACHE INTERNAL "-")
-set(BUILD_TESTS OFF CACHE BOOL "-")
-mark_as_advanced(FORCE BUILD_TESTS)
-add_subdirectory(${FLAMEGPU_ROOT})
 
 # Option to enable/disable building the visualisation
 option(VISUALISATION "Enable visualisation support" OFF)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ cmake .. -DCMAKE_BUILD_TYPE=Release -DCUDA_ARCH=70 -DSEATBELTS=OFF -DUSE_NVTX=ON
 ALL_BUILD.sln
 ```
 
+### Configuring with an out-of-tree FLAMEGPU2
+
+The relevant version of the main FLAMEGPU2 repository will be downloaded via CMake/git at configure time, into `<build>/_deps/FLAMEGPU2-src`.
+Instead, you can provide your own local copy of FLAMEGPU2, via `FETCHCONTENT_SOURCE_DIR_FLAMEGPU2`. This will only re-use source files, and not re-use any build directories on disk at the other local location.
+
+i.e.
+```bash
+cmake .. -DFETCHCONTENT_SOURCE_DIR_FLAMEGPU2=/path/to/FLAMEGPU2
+```
+
+
 ## Running The Examples
 
 The below commands will execute the respective models for several steps, and generate both a timeline and full Nsight Compute data collection.

--- a/cmake/flamegpu2.cmake
+++ b/cmake/flamegpu2.cmake
@@ -19,8 +19,17 @@ FetchContent_GetProperties(flamegpu2)
 if(NOT flamegpu2_POPULATED)
     FetchContent_Populate(flamegpu2)   
 
+    # Now disable extra bells/whistles and add flamegpu2 as a dependency
+    set(NO_EXAMPLES ON CACHE INTERNAL "-")
+    set(BUILD_TESTS OFF CACHE BOOL "-")
+    mark_as_advanced(FORCE BUILD_TESTS)
+
+    # Add the subdirectory
+    add_subdirectory(${flamegpu2_SOURCE_DIR} ${flamegpu2_BINARY_DIR})
+
     # Add flamegpu2' expected location to the prefix path.
     set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${flamegpu2_SOURCE_DIR}/cmake")
 endif()
-    message(STATUS ${flamegpu2_SOURCE_DIR})
-    set(FLAMEGPU_ROOT ${flamegpu2_SOURCE_DIR})
+
+message(STATUS ${flamegpu2_SOURCE_DIR})
+set(FLAMEGPU_ROOT ${flamegpu2_SOURCE_DIR})


### PR DESCRIPTION
This enables the use of `-DFETCHCONTENT_SOURCE_DIR_FLAMEGPU2` to point to a local, out of tree copy of the main flamegpu source respository.

For the purposes of the hackathon this should be fine. Longer term we might want to write a better find FLAMEGPU2 cmake module, but this depends on us providing usable / useful verison numbers in practice so of limited use until we commit to meaingful version numbers.  